### PR TITLE
Tested on 0.10.0 and updated pakcage.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/pconstr/irf"
   },
   "engines": {
-    "node": ">=0.6.0 <0.9.0"
+    "node": ">=0.6.0 <=0.10.0"
   },
   "author": "Carlos Guerreiro <carlos@perceptiveconstructs.com (http://perceptiveconstructs.com)",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "irf",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "keywords": ["incremental", "random", "forest", "machine", "learning", "c++", "native", "sparse", "classifier", "ensemble", "supervised"],
   "homepage": "https://github.com/pconstr/irf",
   "description": "incremental random forest ensemble classifier (native)",


### PR DESCRIPTION
Tested on 0.10.0 and updated package.json, to allow npm installation on more recent node versions.  I'd remove the maximum version limit until a version comes out that breaks it, personally, I'll do it if you give me permission, but it's your npm module, so I'm following your syntax.  These are the versions it's tested under, after all.  My tests are not thorough yet.
